### PR TITLE
Initialize currEvent before entering switch for event type

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -90,9 +90,9 @@ func Notify(uri string, evCh chan<- *Event) error {
 			continue
 		}
 
+		currEvent = &Event{URI: uri}
 		switch string(spl[0]) {
 		case eName:
-			currEvent = &Event{URI: uri}
 			currEvent.Type = string(bytes.TrimSpace(spl[1]))
 		case dName:
 			currEvent.Data = bytes.NewBuffer(bytes.TrimSpace(spl[1]))


### PR DESCRIPTION
Hey @andrewstuart! Looks like `currEvent` isn't initialized within the `dName` block of your switch, so when trying to use your client, I was getting nil pointer references as events were received.